### PR TITLE
Yogclient

### DIFF
--- a/doc-client/src/layouts/blank/BlankLayout.js
+++ b/doc-client/src/layouts/blank/BlankLayout.js
@@ -3,10 +3,12 @@ import React, { Suspense } from "react";
 import frontendRoutes from "../../shared/routes/frontendRoutes";
 import { Routes, Route } from "react-router-dom";
 import CircularProgress from "@mui/material/CircularProgress";
+import Header from "./Header";
 
 const BlankLayout = () => {
   return (
     <>
+      <Header />
       <Suspense fallback={<CircularProgress />}>
         <Routes>
           {Array.isArray(frontendRoutes) &&

--- a/doc-client/src/layouts/blank/Header.js
+++ b/doc-client/src/layouts/blank/Header.js
@@ -1,0 +1,52 @@
+import * as React from "react";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
+import IconButton from "@mui/material/IconButton";
+import MenuIcon from "@mui/icons-material/Menu";
+import { styled } from "@mui/material/styles";
+import { NavLink } from "react-router-dom";
+import frontendRoutes from "../../shared/routes/frontendRoutes";
+
+const Header = () => {
+  const Link = styled(NavLink)({
+    textDecoration: "none",
+    marginRight: 10,
+  });
+
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            Doctors Appointment
+          </Typography>
+          {Array.isArray(frontendRoutes) &&
+            frontendRoutes?.map(({ path, label }, i) => (
+              <Link
+                key={path + i}
+                to={path}
+                style={({ isActive }) => ({
+                  color: isActive ? "#999" : "#fff",
+                })}
+              >
+                {label}
+              </Link>
+            ))}
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default Header;

--- a/doc-client/src/shared/routes/frontendRoutes.js
+++ b/doc-client/src/shared/routes/frontendRoutes.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-anonymous-default-export */
 import React, { lazy } from "react";
 
 import HomeIcon from "@mui/icons-material/Home";


### PR DESCRIPTION
Reinstall react-router-dom package, if module not found error occurs, creating header component as appbar for public pages and importing in blank layout.